### PR TITLE
chore(cli): refactor required and positional args

### DIFF
--- a/.github/workflows/languagetool.yml
+++ b/.github/workflows/languagetool.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
     paths:
-    - 'README.md'
+    - README.md
   workflow_dispatch:
 
 name: LanguageTool check
@@ -10,9 +10,9 @@ jobs:
   languagetool_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: reviewdog/action-languagetool@v1
-        with:
-          reporter: github-pr-review
-          patterns: 'README.md'
-          level: warning
+    - uses: actions/checkout@v1
+    - uses: reviewdog/action-languagetool@v1
+      with:
+        reporter: github-pr-review
+        patterns: README.md
+        level: warning

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ UnTeX has multiple commands, each one with a specific application:
 
 * `parse` for parsing and validating TeX documents[*](#disclaimers).
 
-* `completions` to generate completions scripts for your shell (needs `"cli-complete"` feature).
+* `completions` to generate completions scripts for your shell 
+(needs `"cli-complete"` feature).
 
 ```bash
 untex <COMMAND> [OPTIONS] [FILENAMES]...

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ UnTeX has multiple commands, each one with a specific application:
 untex <COMMAND> [OPTIONS] [FILENAMES]...
 ```
 
-A complete usage help can be obtained with `untex [-h|--help]` or with 
+A complete usage help can be obtained with `untex [-h|--help]` or with
 `untex <COMMAND> [-h|--help]` for a given command.
 
 ### Examples
@@ -59,6 +59,7 @@ A complete usage help can be obtained with `untex [-h|--help]` or with
 untex hl -p math main.tex
 echo "% this is a comment\nthis is not a comment" | untex hl -t comment
 ```
+
 ## Library
 
 You can use UnTeX in your Rust project by adding to your `Cargo.toml`:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ UnTeX has multiple commands, each one with a specific application:
 
 * `parse` for parsing and validating TeX documents[*](#disclaimers).
 
-* `completions` to generate completions scripts for your shell 
+* `completions` to generate completions scripts for your shell
 (needs `"cli-complete"` feature).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -42,10 +42,23 @@ UnTeX has multiple commands, each one with a specific application:
 
 * `parse` for parsing and validating TeX documents[*](#disclaimers).
 
+* `completions` to generate completions scripts for your shell (needs `"cli-complete"` feature).
+
 ```bash
-untex <COMMAND> [OPTIONS] [REQUIRED ARGS]...
+untex <COMMAND> [OPTIONS] [FILENAMES]...
 ```
 
+A complete usage help can be obtained with `untex [-h|--help]` or with 
+`untex <COMMAND> [-h|--help]` for a given command.
+
+### Examples
+
+#### Highlighting text
+
+```bash
+untex hl -p math main.tex
+echo "% this is a comment\nthis is not a comment" | untex hl -t comment
+```
 ## Library
 
 You can use UnTeX in your Rust project by adding to your `Cargo.toml`:

--- a/src/lib/cli/io.rs
+++ b/src/lib/cli/io.rs
@@ -45,7 +45,7 @@ pub struct InputArgs {
     ///
     /// If multiple filenames are provided, calls to `\input{...}` and `\include{...}` are ignored,
     /// even if `follow-includes` is present.
-    #[arg(num_args(1..), last(true), value_parser = parse_filename)]
+    #[arg(num_args(0..), value_parser = parse_filename)]
     pub filenames: Vec<PathBuf>,
 
     /// If set, read files from calls to `\input{...}` and `\include{...}`.


### PR DESCRIPTION
After a few thoughts, I think the only positional argument should be "FILENAMES". The default behavior when FILENAMES is still to be decided (currently, it reads stdin).

The goal is to have a CLI that is close to other major TeX tools.