### PR TITLE
chore(cli): prepare for format cmd implementation

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -15,7 +15,7 @@ pub fn main() {
         Command::Dependencies => issue!(8),
         Command::Expand => issue!(9),
         Command::Highlight(cmd) => cmd.execute().unwrap(),
-        Command::Format => issue!(10),
+        Command::Format(cmd) => cmd.execute().unwrap(),
         Command::Parse => issue!(11),
         #[cfg(feature = "cli-complete")]
         Command::Completions(cmd) => cmd.execute().unwrap(),

--- a/src/lib/cli/format.rs
+++ b/src/lib/cli/format.rs
@@ -1,0 +1,35 @@
+//! (La)TeX code pretty formatting with [`latex::format`](crate::latex::format).
+//!
+use crate::cli::io::{InputArgs, OutputArgs};
+use crate::cli::traits::Execute;
+use crate::latex::format::*;
+use crate::latex::token::Token;
+use clap::Parser;
+use logos::Logos;
+
+/// Command structure to highlight parts of TeX codes.
+#[derive(Debug, Parser)]
+#[command(about = "Pretty format TeX document(s).")]
+pub struct FormatCommand {
+    #[command(flatten)]
+    #[allow(missing_docs)]
+    pub input_args: InputArgs,
+    #[command(flatten)]
+    #[allow(missing_docs)]
+    pub output_args: OutputArgs,
+}
+
+impl Execute for FormatCommand {
+    type Error = std::io::Error;
+    fn execute(self) -> Result<(), Self::Error> {
+        let mut stdout = self.output_args.stdout();
+        let sources = self.input_args.read_sources().unwrap();
+
+        for source in sources.iter() {
+            let iter = Token::lexer(source.as_str()).spanned();
+
+            DummyFormatter::new(iter).write_formatted(source.as_str(), &mut stdout)?;
+        }
+        Ok(())
+    }
+}

--- a/src/lib/cli/io.rs
+++ b/src/lib/cli/io.rs
@@ -33,7 +33,7 @@ fn parse_directory(s: &str) -> Result<PathBuf, String> {
     if path_buf.is_dir() {
         Ok(path_buf)
     } else {
-        Err(format!("Invalid directory: {}", s))
+        Err(format!("Invalid directory: {s}"))
     }
 }
 

--- a/src/lib/cli/io.rs
+++ b/src/lib/cli/io.rs
@@ -22,7 +22,7 @@ fn parse_filename(s: &str) -> Result<PathBuf, String> {
     if path_buf.is_file() {
         Ok(path_buf)
     } else {
-        Err(format!("Invalid filename: {}", s))
+        Err(format!("Invalid filename: {s}"))
     }
 }
 

--- a/src/lib/cli/mod.rs
+++ b/src/lib/cli/mod.rs
@@ -7,6 +7,7 @@
 //! This is why subcommands derive the [`clap::Parser`] trait.
 
 pub mod color;
+pub mod format;
 pub mod highlight;
 pub mod io;
 pub mod traits;
@@ -42,7 +43,7 @@ pub enum Command {
     #[clap(visible_alias = "hl")]
     Highlight(highlight::HighlightCommand),
     #[clap(visible_alias = "fmt")]
-    Format,
+    Format(format::FormatCommand),
     Parse,
     #[cfg(feature = "cli-complete")]
     Completions(complete::CompleteCommand),

--- a/src/lib/latex/format.rs
+++ b/src/lib/latex/format.rs
@@ -31,3 +31,37 @@ pub trait Formatter<'source>: Iterator<Item = SpannedToken<'source>> {
 }
 
 impl<'source, I> Formatter<'source> for I where I: Iterator<Item = SpannedToken<'source>> {}
+
+/// Dommy formatter, should be removed before v4.0 is released.
+#[derive(Debug)]
+pub struct DummyFormatter<'source, I>
+where
+    I: Iterator<Item = SpannedToken<'source>>,
+{
+    iter: I,
+}
+
+impl<'source, I> DummyFormatter<'source, I>
+where
+    I: Iterator<Item = SpannedToken<'source>>,
+{
+    /// Create a new dummy formatter.
+    pub fn new(iter: I) -> Self {
+        Self { iter }
+    }
+}
+
+impl<'source, I> Iterator for DummyFormatter<'source, I>
+where
+    I: Iterator<Item = SpannedToken<'source>>,
+{
+    type Item = SpannedToken<'source>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Dummy formatter skips comments
+        match self.iter.next() {
+            Some((Token::Comment, _)) => self.next(),
+            next => next,
+        }
+    }
+}


### PR DESCRIPTION
This prepares libray and cli to accept a `format` command. A dummy formatter is implemented, and it skips comments. Future PRs on this should allow closing #10.