### PR TITLE
chore(lib): move lib/parse to lib/latex/parse

### DIFF
--- a/src/lib/latex/mod.rs
+++ b/src/lib/latex/mod.rs
@@ -8,4 +8,5 @@
 //! available here: <https://latexref.xyz/dev/latex2e.pdf>.
 pub mod format;
 pub mod highlight;
+pub mod parse;
 pub mod token;

--- a/src/lib/latex/parse.rs
+++ b/src/lib/latex/parse.rs
@@ -1,3 +1,6 @@
+//! *WIP* Parsing [`Token`] iterators into more usable structures.
+
+/*
 use crate::error::Result;
 use crate::token::Token;
 use itertools::Itertools;
@@ -141,3 +144,4 @@ struct Environment<'source> {
     args: Option<Arguments<'source>>,
     span: Span,
 }
+*/


### PR DESCRIPTION
This moves old `parse` module inside `latex` module, and put everything in comments until rework is done.