### PR TITLE
chore(lib): fix typo in doc string

### DIFF
--- a/src/lib/cli/format.rs
+++ b/src/lib/cli/format.rs
@@ -1,5 +1,5 @@
 //! (La)TeX code pretty formatting with [`latex::format`](crate::latex::format).
-//!
+
 use crate::cli::io::{InputArgs, OutputArgs};
 use crate::cli::traits::Execute;
 use crate::latex::format::*;

--- a/src/lib/cli/format.rs
+++ b/src/lib/cli/format.rs
@@ -7,7 +7,7 @@ use crate::latex::token::Token;
 use clap::Parser;
 use logos::Logos;
 
-/// Command structure to highlight parts of TeX codes.
+/// Command structure to pretty format TeX documents.
 #[derive(Debug, Parser)]
 #[command(about = "Pretty format TeX document(s).")]
 pub struct FormatCommand {


### PR DESCRIPTION
Previous doc was about highlighting which is incorrect.