### PR TITLE
chore(cli): add Error enumerate

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use untex::cli::*;
+use untex::error::Result;
 
 macro_rules! issue {
     ($issue:expr) => {
@@ -7,17 +8,19 @@ macro_rules! issue {
     };
 }
 
-pub fn main() {
+pub fn main() -> Result<()> {
     let cli = Cli::parse_from(wild::args());
 
     match cli.command {
         Command::Check => issue!(7),
         Command::Dependencies => issue!(8),
         Command::Expand => issue!(9),
-        Command::Highlight(cmd) => cmd.execute().unwrap(),
-        Command::Format(cmd) => cmd.execute().unwrap(),
+        Command::Highlight(cmd) => cmd.execute()?,
+        Command::Format(cmd) => cmd.execute()?,
         Command::Parse => issue!(11),
         #[cfg(feature = "cli-complete")]
-        Command::Completions(cmd) => cmd.execute().unwrap(),
+        Command::Completions(cmd) => cmd.execute()?,
     }
+
+    Ok(())
 }

--- a/src/lib/cli/complete.rs
+++ b/src/lib/cli/complete.rs
@@ -1,6 +1,7 @@
 //! Completion scripts generation with [`clap_complete`].
 
 use super::traits::Execute;
+use crate::error::Error;
 use clap::{Command, Parser};
 use clap_complete::{generate, shells::Shell};
 use std::io;
@@ -30,7 +31,7 @@ impl CompleteCommand {
 }
 
 impl Execute for CompleteCommand {
-    type Error = io::Error;
+    type Error = Error;
     fn execute(self) -> Result<(), Self::Error> {
         self.generate_completion_file(super::build_cli, &mut io::stdout());
         Ok(())

--- a/src/lib/cli/format.rs
+++ b/src/lib/cli/format.rs
@@ -2,6 +2,7 @@
 
 use crate::cli::io::{InputArgs, OutputArgs};
 use crate::cli::traits::Execute;
+use crate::error::Error;
 use crate::latex::format::*;
 use crate::latex::token::Token;
 use clap::Parser;
@@ -20,7 +21,7 @@ pub struct FormatCommand {
 }
 
 impl Execute for FormatCommand {
-    type Error = std::io::Error;
+    type Error = Error;
     fn execute(self) -> Result<(), Self::Error> {
         let mut stdout = self.output_args.stdout();
         let sources = self.input_args.read_sources().unwrap();

--- a/src/lib/cli/highlight.rs
+++ b/src/lib/cli/highlight.rs
@@ -2,6 +2,7 @@
 
 use crate::cli::io::{InputArgs, OutputArgs};
 use crate::cli::traits::Execute;
+use crate::error::Error;
 use crate::latex::highlight::*;
 use crate::latex::token::{Token, TokenDiscriminants};
 use clap::{Parser, ValueEnum};
@@ -53,7 +54,7 @@ pub struct HighlightCommand {
 }
 
 impl Execute for HighlightCommand {
-    type Error = std::io::Error;
+    type Error = Error;
     fn execute(self) -> Result<(), Self::Error> {
         let mut stdout = self.output_args.stdout();
         let sources = self.input_args.read_sources().unwrap();

--- a/src/lib/cli/io.rs
+++ b/src/lib/cli/io.rs
@@ -1,5 +1,6 @@
 //! Input and Output command-line tools.
 
+use crate::error::{Error, Result};
 use clap::{Args, ValueEnum};
 use is_terminal::IsTerminal;
 use std::io;
@@ -16,24 +17,24 @@ pub enum Choice {
 }
 
 /// Parse a string slice into a [`PathBuf`], and error if the file does not exist.
-fn parse_filename(s: &str) -> Result<PathBuf, String> {
+fn parse_filename(s: &str) -> Result<PathBuf> {
     let path_buf: PathBuf = s.parse().unwrap();
 
     if path_buf.is_file() {
         Ok(path_buf)
     } else {
-        Err(format!("Invalid filename: {s}"))
+        Err(Error::InvalidFilename(s.to_string()))
     }
 }
 
 /// Parse a string slice into a [`PathBuf`], and error if the directory does not exist.
-fn parse_directory(s: &str) -> Result<PathBuf, String> {
+fn parse_directory(s: &str) -> Result<PathBuf> {
     let path_buf: PathBuf = s.parse().unwrap();
 
     if path_buf.is_dir() {
         Ok(path_buf)
     } else {
-        Err(format!("Invalid directory: {s}"))
+        Err(Error::InvalidDirectory(s.to_string()))
     }
 }
 
@@ -64,13 +65,13 @@ impl InputArgs {
         self.filenames.iter().map(|p| p.to_str().unwrap()).collect()
     }
     /// Read one or more sources, either from filenames or frind standard input.
-    pub fn read_sources(&self) -> io::Result<Vec<String>> {
+    pub fn read_sources(&self) -> Result<Vec<String>> {
         let sources: Vec<String> = if self.filenames.is_empty() {
             let mut source = String::new();
             read_from_stdin(&mut io::stdout(), &mut source)?;
             vec![source]
         } else {
-            let sources: Result<Vec<String>, _> =
+            let sources: std::result::Result<Vec<String>, _> =
                 self.filenames.iter().map(std::fs::read_to_string).collect();
             sources?
         };
@@ -81,7 +82,7 @@ impl InputArgs {
 /// Read lines from standard input and write to buffer string.
 ///
 /// Standard output is used when waiting for user to input text.
-pub fn read_from_stdin<W>(stdout: &mut W, buffer: &mut String) -> io::Result<()>
+pub fn read_from_stdin<W>(stdout: &mut W, buffer: &mut String) -> Result<()>
 where
     W: io::Write,
 {

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,6 +1,24 @@
-use thiserror::Error;
+//! Error and Result structures used all across this crate.
 
-#[derive(Error, Debug)]
-pub enum Error {}
+/// Enumeration of all possible error types.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error from reading and writing to IO (see [`std::io::Error`]).
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
 
+    /// Error from parsing category code.
+    #[error("invalid category code (got '{0}', must be between 0 and 15 included)")]
+    InvalidCategoryCode(String),
+
+    /// Error from checking if `directory` exists and is a actually a directory.
+    #[error("invalid directory (got '{0}', does not exist or is not a directory)")]
+    InvalidDirectory(String),
+
+    /// Error from checking if `filename` exists and is a actualla a file.
+    #[error("invalid filename (got '{0}', does not exist or is not a file)")]
+    InvalidFilename(String),
+}
+
+/// Result type alias with error type defined above (see [`Error`]).
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib/latex/highlight.rs
+++ b/src/lib/latex/highlight.rs
@@ -1,4 +1,5 @@
 //! Highlighting parts of LaTeX documents via [`Token`] iterators.
+use crate::error::Result;
 #[cfg(feature = "strum")]
 use crate::latex::token::TokenDiscriminants;
 use crate::latex::token::{Span, SpannedToken, Token};
@@ -50,7 +51,7 @@ pub trait Highlighter<'source>: Iterator<Item = (bool, SpannedToken<'source>)> {
         source: &'source str,
         buffer: &mut W,
         highlight_color: &ColorSpec,
-    ) -> std::io::Result<()>
+    ) -> Result<()>
     where
         W: WriteColor,
     {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -30,6 +30,7 @@
 //! on improving this tool.
 #[cfg(feature = "cli")]
 pub mod cli;
+pub mod error;
 pub mod latex;
 pub mod prelude;
 pub mod tex;

--- a/src/lib/tex/category_codes.rs
+++ b/src/lib/tex/category_codes.rs
@@ -5,6 +5,7 @@
 //! Since TeX is limited to ASCII characters (by default), functions defined
 //! here are working with bytes (slice of [`u8`]) instead of [`str`].
 
+use crate::error::Error;
 use logos::Logos;
 
 #[derive(Debug, PartialEq, Logos)]
@@ -113,7 +114,7 @@ pub enum CategoryCode {
 macro_rules! impl_try_from {
     ($ty:ty) => {
         impl std::convert::TryFrom<$ty> for CategoryCode {
-            type Error = $ty;
+            type Error = Error;
             #[inline]
             fn try_from(code: $ty) -> Result<Self, Self::Error> {
                 match code {
@@ -133,7 +134,7 @@ macro_rules! impl_try_from {
                     13 => Ok(CategoryCode::Active),
                     14 => Ok(CategoryCode::CommentChar),
                     15 => Ok(CategoryCode::InvalidChar),
-                    x => Err(x),
+                    x => Err(Error::InvalidCategoryCode(x.to_string())),
                 }
             }
         }


### PR DESCRIPTION
This adds a "basic" but sufficient Error enum. that implements the `Error` trait. From now on, all results should use some kind of variant of this new enum.

Closes #13.